### PR TITLE
 Implemented Denied Page for Restricted Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ This will start the development server and you can view the application in your 
     <td>Chatbot</td>
     <td>/chatbot</td>
   </tr>
+  <tr>
+    <td>Denied</td>
+    <td>/denied</td>
+  </tr>
 </table>
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-google-maps/api": "^2.19.3",
         "@yaireo/tagify": "^4.27.0",
         "axios": "^1.7.4",
+        "dotenv": "^16.4.5",
         "framer-motion": "^11.3.28",
         "gsap": "^3.12.5",
         "moment": "^2.30.1",
@@ -2082,6 +2083,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-google-maps/api": "^2.19.3",
     "@yaireo/tagify": "^4.27.0",
     "axios": "^1.7.4",
+    "dotenv": "^16.4.5",
     "framer-motion": "^11.3.28",
     "gsap": "^3.12.5",
     "moment": "^2.30.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import Requests from "./pages/Requests";
 import CodeRun from "./pages/CodeRun";
 import Matches from "./pages/Matches";
 import RoomPage from "./pages/Room";
+import Denied from "./pages/Denied";
+import Chat from "./pages/Matches";
 
 
 /* TO  ACCESS ANY PAGE YOU CAN REMOVE THE RESTRICTIONS BY SIMPLY REPLACING THE 
@@ -38,54 +40,22 @@ const App = () => {
             <Route path="/" element={<Landing />} />
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
-            <Route path='/room/:roomId' element={<RoomPage />}/>
-            <Route path="/coderun" element={user ? <CodeRun /> : <Landing />} />
+            <Route path="/room/:roomId" element={<RoomPage />} />
+            <Route path="/coderun" element={user ? <CodeRun /> : <Denied />} />
 
-            {/* Restrict access to Dashboard if user is Male */}
+            {/* Restrict Access to dashboard for Males */}
             <Route
               path="/dashboard"
               element={
-                user && user.gender !== "Male" ? (
+                user && user.gender === "Female" ? (
                   <Layout1>
                     <Dashboard />
                   </Layout1>
                 ) : (
-                  <Landing />
+                  <Denied />
                 )
               }
             />
-             
-
-            <Route
-              path="/matches"
-              element={
-                user ? (
-                  <Layout1>
-                    <Matches />
-                  </Layout1>
-                ) : (
-                  <Landing />
-                )
-              }
-            />
-
-         
-
-            {/* Restrict access to Requests if user is Female */}
-            <Route
-              path="/request"
-              element={
-                user && user.gender !== "Female" ? (
-                  <Layout1>
-                    <Requests />
-                  </Layout1>
-                ) : (
-                  <Landing />
-                )
-              }
-            />
-
-         
 
             <Route
               path="/queue"
@@ -95,11 +65,38 @@ const App = () => {
                     <Queue />
                   </Layout1>
                 ) : (
-                  <Landing />
+                  <Denied />
                 )
               }
             />
 
+            {/* Restrict Access for Females */}
+            <Route
+              path="/request"
+              element={
+                user && user.gender === "Male" ? (
+                  <Layout1>
+                    <Requests />
+                  </Layout1>
+                ) : (
+                  <Denied />
+                )
+              }
+            />
+
+            {/* Restricted Access for Unauthenticated Users */}
+            <Route
+              path="/matches"
+              element={
+                user ? (
+                  <Layout1>
+                    <Matches />
+                  </Layout1>
+                ) : (
+                  <Denied />
+                )
+              }
+            />
             <Route
               path="/chatbot"
               element={
@@ -108,10 +105,12 @@ const App = () => {
                     <Chatbot />
                   </Layout1>
                 ) : (
-                  <Landing />
+                  <Denied />
                 )
               }
             />
+
+            <Route path="/denied" element={<Denied />} />
           </Routes>
         </ExtraContextProvider>
       </AIChatContextProvider>

--- a/src/pages/Denied.jsx
+++ b/src/pages/Denied.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaLock } from "react-icons/fa";
+import { motion } from "framer-motion";
+
+const Denied = () => {
+    return (
+        <div className="bg-black text-gray-200 w-full h-screen flex flex-col items-center justify-center px-6 py-4">
+            <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ duration: 0.5 }}
+                className="text-center"
+            >
+            
+                <motion.div
+                    className="flex justify-center items-center mb-4"
+                    initial={{ rotate: 0 }}
+                    animate={{ rotate: 360 }}
+                    transition={{ type: "spring", stiffness: 150, duration: 1 }}
+                >
+                    <FaLock className="text-6xl text-[#ff0059]" />
+                </motion.div>
+
+                
+                <h1 className="text-5xl font-bold mb-4">
+                    Access Denied!
+                </h1>
+
+
+                <motion.p
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.2, duration: 0.5 }}
+                    className="text-xl text-gray-400"
+                >
+                    Oops! Looks like you're trying to unlock a door that doesn’t belong to you.
+                </motion.p>
+
+            
+                <Link to="/">
+                    <motion.button
+                        whileHover={{ scale: 1.1 }}
+                        whileTap={{ scale: 0.95 }}
+                        className="bg-[#ff0059] hover:bg-red-500 text-white font-bold text-xl py-2 px-6 rounded-lg mt-8"
+                    >
+                        Take Me Home
+                    </motion.button>
+                </Link>
+
+
+                <motion.p
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.5, duration: 0.5 }}
+                    className="mt-8 text-gray-400"
+                >
+                    Want to explore? Maybe you need the right key. 🗝️
+                </motion.p>
+            </motion.div>
+        </div>
+    );
+};
+
+export default Denied;


### PR DESCRIPTION
This PR introduces a dedicated Denied Page to handle cases where users attempt to access restricted routes based on their gender or authentication status. Instead of redirecting users to the landing page, the system will now show a denied page for improved user experience and better route protection. This enhancement also leverages a RequireAuth component for cleaner and more maintainable route handling logic.

Changes Made:

- Created Denied component to display a message when access is denied.
- Replaced existing landing page redirection with the new denied page for restricted routes.
- Updated route protection using RequireAuth to handle gender-based and authentication-based restrictions.
- Ensured unauthorized users are shown the denied page instead of the landing page.
- Updated the route configuration to maintain a clean and modular approach.


![Screenshot 2024-10-01 145611](https://github.com/user-attachments/assets/cf48cb2a-19c6-4abe-a7f7-b944c6beea01)

This PR closes #19 